### PR TITLE
Implement basic plugin startup classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,21 @@
-<project>
-  <!-- Placeholder Maven definition -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>marvtech</groupId>
+    <artifactId>lynxplugin</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>5.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.44.1.0</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/src/main/java/marvtech/lynx/Lynx.java
+++ b/src/main/java/marvtech/lynx/Lynx.java
@@ -5,18 +5,42 @@ import marvtech.lynx.commands.BankCommand;
 import marvtech.lynx.commands.CountryCommand;
 import marvtech.lynx.commands.FactionCommand;
 import marvtech.lynx.commands.LynxCommand;
+import marvtech.lynx.country.repository.CountryRepository;
+import marvtech.lynx.country.service.CountryService;
+import marvtech.lynx.faction.repository.FactionRepository;
+import marvtech.lynx.faction.service.FactionService;
 import marvtech.lynx.listeners.ChunkClaimListener;
 import marvtech.lynx.listeners.PlayerJoinListener;
 import marvtech.lynx.listeners.VaultBalanceListener;
+import marvtech.lynx.util.DatabaseProvider;
+import com.zaxxer.hikari.HikariDataSource;
 import org.bukkit.plugin.java.JavaPlugin;
 
 /**
  * Main plugin class.
  */
 public class Lynx extends JavaPlugin {
+    private HikariDataSource dataSource;
+    private CountryService countryService;
+    private FactionService factionService;
 
     @Override
     public void onEnable() {
+        // Initialize persistence
+        dataSource = DatabaseProvider.createSQLiteDataSource(getDataFolder());
+        CountryRepository countryRepository = new CountryRepository(dataSource);
+        FactionRepository factionRepository = new FactionRepository(dataSource);
+        try {
+            countryRepository.init();
+            factionRepository.init();
+        } catch (Exception e) {
+            getLogger().severe("Failed to initialise database: " + e.getMessage());
+        }
+
+        // Create services
+        countryService = new CountryService(countryRepository);
+        factionService = new FactionService(factionRepository);
+
         // Register command executors
         getCommand("lynx").setExecutor(new LynxCommand());
         getCommand("admin").setExecutor(new AdminCommand());
@@ -34,6 +58,9 @@ public class Lynx extends JavaPlugin {
 
     @Override
     public void onDisable() {
+        if (dataSource != null) {
+            dataSource.close();
+        }
         getLogger().info("Lynx disabled");
     }
 }

--- a/src/main/java/marvtech/lynx/Lynx.java
+++ b/src/main/java/marvtech/lynx/Lynx.java
@@ -1,7 +1,39 @@
 package marvtech.lynx;
 
+import marvtech.lynx.commands.AdminCommand;
+import marvtech.lynx.commands.BankCommand;
+import marvtech.lynx.commands.CountryCommand;
+import marvtech.lynx.commands.FactionCommand;
+import marvtech.lynx.commands.LynxCommand;
+import marvtech.lynx.listeners.ChunkClaimListener;
+import marvtech.lynx.listeners.PlayerJoinListener;
+import marvtech.lynx.listeners.VaultBalanceListener;
+import org.bukkit.plugin.java.JavaPlugin;
+
 /**
- * Plugin main class placeholder.
+ * Main plugin class.
  */
-public class Lynx {
+public class Lynx extends JavaPlugin {
+
+    @Override
+    public void onEnable() {
+        // Register command executors
+        getCommand("lynx").setExecutor(new LynxCommand());
+        getCommand("admin").setExecutor(new AdminCommand());
+        getCommand("country").setExecutor(new CountryCommand());
+        getCommand("bank").setExecutor(new BankCommand());
+        getCommand("faction").setExecutor(new FactionCommand());
+
+        // Register event listeners
+        getServer().getPluginManager().registerEvents(new ChunkClaimListener(), this);
+        getServer().getPluginManager().registerEvents(new PlayerJoinListener(), this);
+        getServer().getPluginManager().registerEvents(new VaultBalanceListener(), this);
+
+        getLogger().info("Lynx enabled");
+    }
+
+    @Override
+    public void onDisable() {
+        getLogger().info("Lynx disabled");
+    }
 }

--- a/src/main/java/marvtech/lynx/commands/AdminCommand.java
+++ b/src/main/java/marvtech/lynx/commands/AdminCommand.java
@@ -1,5 +1,16 @@
 package marvtech.lynx.commands;
 
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+
 /** Command placeholder for admin. */
-public class AdminCommand {
+public class AdminCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command,
+                             @NotNull String label, @NotNull String[] args) {
+        sender.sendMessage("Admin command executed");
+        return true;
+    }
 }

--- a/src/main/java/marvtech/lynx/commands/BankCommand.java
+++ b/src/main/java/marvtech/lynx/commands/BankCommand.java
@@ -1,5 +1,16 @@
 package marvtech.lynx.commands;
 
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+
 /** Command placeholder for bank. */
-public class BankCommand {
+public class BankCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command,
+                             @NotNull String label, @NotNull String[] args) {
+        sender.sendMessage("Bank command executed");
+        return true;
+    }
 }

--- a/src/main/java/marvtech/lynx/commands/CountryCommand.java
+++ b/src/main/java/marvtech/lynx/commands/CountryCommand.java
@@ -1,5 +1,16 @@
 package marvtech.lynx.commands;
 
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+
 /** Command placeholder for country. */
-public class CountryCommand {
+public class CountryCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command,
+                             @NotNull String label, @NotNull String[] args) {
+        sender.sendMessage("Country command executed");
+        return true;
+    }
 }

--- a/src/main/java/marvtech/lynx/commands/FactionCommand.java
+++ b/src/main/java/marvtech/lynx/commands/FactionCommand.java
@@ -1,5 +1,16 @@
 package marvtech.lynx.commands;
 
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+
 /** Command placeholder for faction. */
-public class FactionCommand {
+public class FactionCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command,
+                             @NotNull String label, @NotNull String[] args) {
+        sender.sendMessage("Faction command executed");
+        return true;
+    }
 }

--- a/src/main/java/marvtech/lynx/commands/LynxCommand.java
+++ b/src/main/java/marvtech/lynx/commands/LynxCommand.java
@@ -1,5 +1,16 @@
 package marvtech.lynx.commands;
 
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+
 /** Command placeholder for lynx command. */
-public class LynxCommand {
+public class LynxCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command,
+                             @NotNull String label, @NotNull String[] args) {
+        sender.sendMessage("Lynx command executed");
+        return true;
+    }
 }

--- a/src/main/java/marvtech/lynx/country/model/Country.java
+++ b/src/main/java/marvtech/lynx/country/model/Country.java
@@ -2,4 +2,19 @@ package marvtech.lynx.country.model;
 
 /** Simple POJO for country. */
 public class Country {
+    private final int id;
+    private final String name;
+
+    public Country(int id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
 }

--- a/src/main/java/marvtech/lynx/country/repository/CountryRepository.java
+++ b/src/main/java/marvtech/lynx/country/repository/CountryRepository.java
@@ -1,5 +1,61 @@
 package marvtech.lynx.country.repository;
 
-/** DAO placeholder for country. */
+import com.zaxxer.hikari.HikariDataSource;
+import marvtech.lynx.country.model.Country;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/** Persistence operations for countries. */
 public class CountryRepository {
+    private final HikariDataSource dataSource;
+
+    public CountryRepository(HikariDataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    /** Initialize database table. */
+    public void init() throws SQLException {
+        String sql = "CREATE TABLE IF NOT EXISTS countries (" +
+                     "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                     "name TEXT UNIQUE NOT NULL)";
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.executeUpdate();
+        }
+    }
+
+    /** Persist a new country. */
+    public Country save(String name) throws SQLException {
+        String sql = "INSERT INTO countries(name) VALUES (?)";
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            stmt.setString(1, name);
+            stmt.executeUpdate();
+            try (ResultSet keys = stmt.getGeneratedKeys()) {
+                if (keys.next()) {
+                    return new Country(keys.getInt(1), name);
+                }
+            }
+        }
+        return null;
+    }
+
+    /** Find a country by id. */
+    public Country find(int id) throws SQLException {
+        String sql = "SELECT id, name FROM countries WHERE id = ?";
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setInt(1, id);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return new Country(rs.getInt("id"), rs.getString("name"));
+                }
+            }
+        }
+        return null;
+    }
 }

--- a/src/main/java/marvtech/lynx/country/service/CountryService.java
+++ b/src/main/java/marvtech/lynx/country/service/CountryService.java
@@ -1,5 +1,33 @@
 package marvtech.lynx.country.service;
 
-/** Service placeholder for country business logic. */
+import marvtech.lynx.country.model.Country;
+import marvtech.lynx.country.repository.CountryRepository;
+
+import java.sql.SQLException;
+
+/** Service layer using {@link CountryRepository}. */
 public class CountryService {
+    private final CountryRepository repository;
+
+    public CountryService(CountryRepository repository) {
+        this.repository = repository;
+    }
+
+    /** Create and persist a new country. */
+    public Country createCountry(String name) {
+        try {
+            return repository.save(name);
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to create country", e);
+        }
+    }
+
+    /** Retrieve a country by id. */
+    public Country getCountry(int id) {
+        try {
+            return repository.find(id);
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to fetch country", e);
+        }
+    }
 }

--- a/src/main/java/marvtech/lynx/faction/model/Faction.java
+++ b/src/main/java/marvtech/lynx/faction/model/Faction.java
@@ -2,4 +2,19 @@ package marvtech.lynx.faction.model;
 
 /** Simple POJO for faction. */
 public class Faction {
+    private final int id;
+    private final String name;
+
+    public Faction(int id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
 }

--- a/src/main/java/marvtech/lynx/faction/repository/FactionRepository.java
+++ b/src/main/java/marvtech/lynx/faction/repository/FactionRepository.java
@@ -1,5 +1,61 @@
 package marvtech.lynx.faction.repository;
 
-/** DAO placeholder for faction. */
+import com.zaxxer.hikari.HikariDataSource;
+import marvtech.lynx.faction.model.Faction;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/** Persistence operations for factions. */
 public class FactionRepository {
+    private final HikariDataSource dataSource;
+
+    public FactionRepository(HikariDataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    /** Initialize database table. */
+    public void init() throws SQLException {
+        String sql = "CREATE TABLE IF NOT EXISTS factions (" +
+                     "id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                     "name TEXT UNIQUE NOT NULL)";
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.executeUpdate();
+        }
+    }
+
+    /** Persist a new faction. */
+    public Faction save(String name) throws SQLException {
+        String sql = "INSERT INTO factions(name) VALUES (?)";
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            stmt.setString(1, name);
+            stmt.executeUpdate();
+            try (ResultSet keys = stmt.getGeneratedKeys()) {
+                if (keys.next()) {
+                    return new Faction(keys.getInt(1), name);
+                }
+            }
+        }
+        return null;
+    }
+
+    /** Find a faction by id. */
+    public Faction find(int id) throws SQLException {
+        String sql = "SELECT id, name FROM factions WHERE id = ?";
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setInt(1, id);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return new Faction(rs.getInt("id"), rs.getString("name"));
+                }
+            }
+        }
+        return null;
+    }
 }

--- a/src/main/java/marvtech/lynx/faction/service/FactionService.java
+++ b/src/main/java/marvtech/lynx/faction/service/FactionService.java
@@ -1,5 +1,33 @@
 package marvtech.lynx.faction.service;
 
-/** Service placeholder for faction operations. */
+import marvtech.lynx.faction.model.Faction;
+import marvtech.lynx.faction.repository.FactionRepository;
+
+import java.sql.SQLException;
+
+/** Service layer for factions. */
 public class FactionService {
+    private final FactionRepository repository;
+
+    public FactionService(FactionRepository repository) {
+        this.repository = repository;
+    }
+
+    /** Create and persist a new faction. */
+    public Faction createFaction(String name) {
+        try {
+            return repository.save(name);
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to create faction", e);
+        }
+    }
+
+    /** Retrieve a faction by id. */
+    public Faction getFaction(int id) {
+        try {
+            return repository.find(id);
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to fetch faction", e);
+        }
+    }
 }

--- a/src/main/java/marvtech/lynx/listeners/ChunkClaimListener.java
+++ b/src/main/java/marvtech/lynx/listeners/ChunkClaimListener.java
@@ -1,5 +1,7 @@
 package marvtech.lynx.listeners;
 
+import org.bukkit.event.Listener;
+
 /** Listener placeholder for chunk claim. */
-public class ChunkClaimListener {
+public class ChunkClaimListener implements Listener {
 }

--- a/src/main/java/marvtech/lynx/listeners/PlayerJoinListener.java
+++ b/src/main/java/marvtech/lynx/listeners/PlayerJoinListener.java
@@ -1,5 +1,7 @@
 package marvtech.lynx.listeners;
 
+import org.bukkit.event.Listener;
+
 /** Listener placeholder for player join. */
-public class PlayerJoinListener {
+public class PlayerJoinListener implements Listener {
 }

--- a/src/main/java/marvtech/lynx/listeners/VaultBalanceListener.java
+++ b/src/main/java/marvtech/lynx/listeners/VaultBalanceListener.java
@@ -1,5 +1,7 @@
 package marvtech.lynx.listeners;
 
+import org.bukkit.event.Listener;
+
 /** Listener placeholder for vault balance. */
-public class VaultBalanceListener {
+public class VaultBalanceListener implements Listener {
 }

--- a/src/main/java/marvtech/lynx/util/DatabaseProvider.java
+++ b/src/main/java/marvtech/lynx/util/DatabaseProvider.java
@@ -1,0 +1,27 @@
+package marvtech.lynx.util;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+
+import java.io.File;
+
+/** Utility for creating database connections. */
+public final class DatabaseProvider {
+    private DatabaseProvider() {
+    }
+
+    /**
+     * Create a SQLite based data source stored in the plugin data folder.
+     *
+     * @param dataFolder plugin data directory
+     * @return configured data source
+     */
+    public static HikariDataSource createSQLiteDataSource(File dataFolder) {
+        File dbFile = new File(dataFolder, "lynx.db");
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl("jdbc:sqlite:" + dbFile.getPath());
+        config.setConnectionTestQuery("SELECT 1");
+        config.setPoolName("LynxPool");
+        return new HikariDataSource(config);
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,20 @@
+name: Lynx
+version: 1.0
+main: marvtech.lynx.Lynx
+api-version: "1.20"
+commands:
+  lynx:
+    description: Main plugin command
+    usage: /lynx
+  admin:
+    description: Admin commands
+    usage: /admin
+  country:
+    description: Country related commands
+    usage: /country
+  bank:
+    description: Bank related commands
+    usage: /bank
+  faction:
+    description: Faction related commands
+    usage: /faction


### PR DESCRIPTION
## Summary
- implement `Lynx` plugin main class that extends `JavaPlugin`
- add simple command executors and listeners
- register commands and listeners on plugin startup
- define plugin metadata and commands in `plugin.yml`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68666c4711608329b2906d9caa16b2bc