### PR TITLE
Fix command registration null-safety

### DIFF
--- a/src/main/java/marvtech/lynx/Lynx.java
+++ b/src/main/java/marvtech/lynx/Lynx.java
@@ -1,5 +1,13 @@
 package marvtech.lynx;
 
+import java.util.Objects;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+import marvtech.lynx.commands.AdminCommand;
+import marvtech.lynx.commands.CountryCommand;
+import marvtech.lynx.commands.FactionCommand;
+import marvtech.lynx.commands.LynxCommand;
 import marvtech.lynx.country.service.CountryService;
 import marvtech.lynx.faction.service.FactionService;
 import marvtech.lynx.economy.EconomyService;
@@ -7,7 +15,7 @@ import marvtech.lynx.economy.EconomyService;
 /**
  * Minimal plugin bootstrap to expose services.
  */
-public class Lynx {
+public class Lynx extends JavaPlugin {
     private static Lynx instance;
     private CountryService countryService;
     private FactionService factionService;
@@ -18,6 +26,18 @@ public class Lynx {
         countryService = new CountryService();
         factionService = new FactionService();
         economyService = new EconomyService();
+    }
+
+    @Override
+    public void onEnable() {
+        Objects.requireNonNull(getCommand("country"))
+            .setExecutor(new CountryCommand(countryService));
+        Objects.requireNonNull(getCommand("faction"))
+            .setExecutor(new FactionCommand(factionService));
+        Objects.requireNonNull(getCommand("lynx"))
+            .setExecutor(new LynxCommand());
+        Objects.requireNonNull(getCommand("admin"))
+            .setExecutor(new AdminCommand(economyService));
     }
 
     public static Lynx getInstance() {
@@ -35,10 +55,5 @@ public class Lynx {
     public EconomyService getEconomyService() {
         return economyService;
     }
-=======
-/**
- * Plugin main class placeholder.
- */
-public class Lynx {
 
 }


### PR DESCRIPTION
## Summary
- import `Objects` and Bukkit classes
- extend `JavaPlugin` and implement a basic `onEnable`
- wrap command lookups in `Objects.requireNonNull`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866712a8acc83298df77a62666d0cd6