### PR TITLE
Improve README with build/test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,24 @@ Paper API.
 
 The project depends on `paper-api` version `1.20.1-R0.1-SNAPSHOT`, which is
 declared with `scope` set to `provided` in the Maven configuration.
+
+## Building
+
+Ensure that Java 17 and Maven 3 are installed. To build the plugin JAR run:
+
+```bash
+mvn clean package
+```
+
+The compiled JAR will be located in `target/`. Since the Paper API is marked as
+provided, it needs to be available on the server at runtime.
+
+## Running Tests
+
+Unit tests can be executed with:
+
+```bash
+mvn test
+```
+
+This repository uses JUnit 5 for testing.


### PR DESCRIPTION
## Summary
- document how to build the plugin with Maven
- add section on running tests with JUnit 5

## Testing
- `mvn -q test` *(fails: `mvn` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686677f4a4e08329928386e54a79b640